### PR TITLE
Bump test dependency compat bounds (supersedes #6 and #8)

### DIFF
--- a/test/Project.toml
+++ b/test/Project.toml
@@ -11,4 +11,10 @@ TruncatedNormal = "57af301a-a58c-11e9-1f68-193042cecb35"
 Zygote = "e88e6eb3-aa80-5325-afca-941959d7151f"
 
 [compat]
-Aqua = "0.6"
+Aqua = "0.6, 0.8"
+Distributions = "0.25.131"
+FiniteDifferences = "0.12.34"
+SafeTestsets = "0.1.0"
+SpecialFunctions = "2.9.0"
+Statistics = "1.11.1"
+Zygote = "0.7.12"

--- a/test/Project.toml
+++ b/test/Project.toml
@@ -10,11 +10,13 @@ Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 TruncatedNormal = "57af301a-a58c-11e9-1f68-193042cecb35"
 Zygote = "e88e6eb3-aa80-5325-afca-941959d7151f"
 
+# [compat] here bounds test-only deps exclusively: names the root Project.toml
+# already owns (SpecialFunctions, Statistics, ...) must not be repeated --
+# workspace members share one manifest, so a repeated bound would be
+# intersected with the root's and silently narrow the real resolve.
 [compat]
 Aqua = "0.6, 0.8"
 Distributions = "0.25.131"
 FiniteDifferences = "0.12.34"
 SafeTestsets = "0.1.0"
-SpecialFunctions = "2.9.0"
-Statistics = "1.11.1"
 Zygote = "0.7.12"

--- a/test/Project.toml
+++ b/test/Project.toml
@@ -10,10 +10,6 @@ Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 TruncatedNormal = "57af301a-a58c-11e9-1f68-193042cecb35"
 Zygote = "e88e6eb3-aa80-5325-afca-941959d7151f"
 
-# [compat] here bounds test-only deps exclusively: names the root Project.toml
-# already owns (SpecialFunctions, Statistics, ...) must not be repeated --
-# workspace members share one manifest, so a repeated bound would be
-# intersected with the root's and silently narrow the real resolve.
 [compat]
 Aqua = "0.6, 0.8"
 Distributions = "0.25.131"


### PR DESCRIPTION
Consolidates the two open dependabot PRs (#6 and #8) into a single change to `test/Project.toml`, keeping it compliant with [TestCompatHygiene.jl](https://github.com/cossio/TestCompatHygiene.jl)'s invariant: no `[compat]` entry in `test/Project.toml` for a name the root `Project.toml` already owns.

Compat updates taken from the dependabot PRs (test-only deps):

- `Aqua = "0.6, 0.8"` (from #8, also included in #6)
- `Distributions = "0.25.131"`
- `FiniteDifferences = "0.12.34"`
- `SafeTestsets = "0.1.0"`
- `Zygote = "0.7.12"`

Deliberately **not** taken from #6: `SpecialFunctions` and `Statistics` — both are deps of the root `Project.toml`, which already bounds them. Workspace members share one manifest, so repeating those bounds in `test/Project.toml` would be intersected with the root's and silently narrow the real resolve (the exact failure mode TestCompatHygiene guards against).

Validated locally on Julia 1.12.1: the workspace resolves, the full test suite passes (Aqua included), and `TestCompatHygiene.check_test_compat` reports no offenders.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013Po9AaxYCxkBVex5BZAYj1